### PR TITLE
Fix package manager detection and command logic

### DIFF
--- a/src/command/autoremove.rs
+++ b/src/command/autoremove.rs
@@ -14,6 +14,7 @@ pub fn gen_autoremove_syntax(manager: String) -> std::process::Command {
         }
         "pacman" => {
             command.arg("-Rns");
+            command.arg("--noconfirm");
         }
         "zypper" => {
             command.arg("remove");
@@ -74,7 +75,7 @@ mod tests {
     fn test_gen_autoremove_syntax_pacman() {
         let cmd = gen_autoremove_syntax("pacman".to_string());
         let args = cmd_to_string(&cmd);
-        assert_eq!(args, vec!["pacman", "-Rns"]);
+        assert_eq!(args, vec!["pacman", "-Rns", "--noconfirm"]);
     }
 
     #[test]

--- a/src/command/install.rs
+++ b/src/command/install.rs
@@ -4,15 +4,19 @@ pub fn gen_install_syntax(manager: String) -> std::process::Command {
     let mut command: std::process::Command = Command::new(manager.clone());
     // add arguments
     match manager.as_str() {
-        "apt" | "dnf" | "yum" | "pacman" | "zypper" => {
+        "apt" | "dnf" | "yum" | "zypper" => {
             command.arg("install");
             command.arg("-y");
+        }
+        "pacman" => {
+            command.arg("-S");
+            command.arg("--noconfirm");
         }
         "apk" => {
             command.arg("add");
         }
         "portage" => {
-            command.arg("emerge");
+            command = Command::new("emerge");
         }
         "brew" => {
             command.arg("install");
@@ -63,7 +67,7 @@ mod tests {
     fn test_gen_install_syntax_pacman() {
         let cmd = gen_install_syntax("pacman".to_string());
         let args = cmd_to_string(&cmd);
-        assert_eq!(args, vec!["pacman", "install", "-y"]);
+        assert_eq!(args, vec!["pacman", "-S", "--noconfirm"]);
     }
 
     #[test]
@@ -84,7 +88,7 @@ mod tests {
     fn test_gen_install_syntax_portage() {
         let cmd = gen_install_syntax("portage".to_string());
         let args = cmd_to_string(&cmd);
-        assert_eq!(args, vec!["portage", "emerge"]);
+        assert_eq!(args, vec!["emerge"]);
     }
 
     #[test]

--- a/src/command/reinstall.rs
+++ b/src/command/reinstall.rs
@@ -9,8 +9,7 @@ pub fn gen_reinstall_syntax(manager: String) -> std::process::Command {
         }
         "pacman" => {
             command.arg("-S");
-            command.arg("--overwrite");
-            command.arg("*");
+            command.arg("--noconfirm");
         }
         "zypper" => {
             command.arg("install");
@@ -68,7 +67,7 @@ mod tests {
     fn test_gen_reinstall_syntax_pacman() {
         let cmd = gen_reinstall_syntax("pacman".to_string());
         let args = cmd_to_string(&cmd);
-        assert_eq!(args, vec!["pacman", "-S", "--overwrite", "*"]);
+        assert_eq!(args, vec!["pacman", "-S", "--noconfirm"]);
     }
 
     #[test]

--- a/src/command/uninstall.rs
+++ b/src/command/uninstall.rs
@@ -17,7 +17,7 @@ pub fn gen_uninstall_syntax(manager: String) -> std::process::Command {
         }
         "pacman" => {
             command.arg("-R");
-            command.arg("-y");
+            command.arg("--noconfirm");
         }
         "brew" => {
             command.arg("uninstall");
@@ -64,7 +64,7 @@ mod tests {
     fn test_gen_uninstall_syntax_pacman() {
         let cmd = gen_uninstall_syntax("pacman".to_string());
         let args = cmd_to_string(&cmd);
-        assert_eq!(args, vec!["pacman", "-R", "-y"]);
+        assert_eq!(args, vec!["pacman", "-R", "--noconfirm"]);
     }
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,19 +1,24 @@
+use std::path::Path;
+
 pub fn detect_package_manager() -> String {
-    if std::path::Path::new("/usr/bin/apt").exists() {
+    if Path::new("/usr/bin/apt").exists() {
         "apt".to_string()
-    } else if std::path::Path::new("/usr/bin/dnf").exists() {
+    } else if Path::new("/usr/bin/dnf").exists() {
         "dnf".to_string()
-    } else if std::path::Path::new("/usr/bin/yum").exists() {
+    } else if Path::new("/usr/bin/yum").exists() {
         "yum".to_string()
-    } else if std::path::Path::new("/opt/homebrew/bin/brew").exists() {
+    } else if Path::new("/opt/homebrew/bin/brew").exists()
+        || Path::new("/usr/local/bin/brew").exists()
+        || Path::new("/home/linuxbrew/.linuxbrew/bin/brew").exists()
+    {
         "brew".to_string()
-    } else if std::path::Path::new("/usr/bin/zypper").exists() {
+    } else if Path::new("/usr/bin/zypper").exists() {
         "zypper".to_string()
-    } else if std::path::Path::new("/usr/bin/pacman").exists() {
+    } else if Path::new("/usr/bin/pacman").exists() {
         "pacman".to_string()
-    } else if std::path::Path::new("/usr/bin/apk").exists() {
+    } else if Path::new("/usr/bin/apk").exists() {
         "apk".to_string()
-    } else if std::path::Path::new("/usr/bin/portage").exists() {
+    } else if Path::new("/usr/bin/emerge").exists() {
         "portage".to_string()
     } else {
         "unknown".to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
         .get_matches();
 
     let package_manager = env::detect_package_manager();
-    if package_manager == "Unknown" {
+    if package_manager == "unknown" {
         eprintln!("Unknown package manager");
         return;
     }
@@ -106,11 +106,14 @@ fn run_package_command(mut cmd: SysCommand, action: &str, silent: bool, verbose:
     // 控制輸出
     if silent {
         cmd.stdout(Stdio::null()).stderr(Stdio::null());
-    } else if !verbose {
+    } else {
         cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     }
 
     let mut cmd = get_sudo(cmd);
+    if verbose && !silent {
+        eprintln!("yu: running {:?}", cmd);
+    }
 
     let status = cmd.status().expect(&format!("failed to {}", action));
 

--- a/src/root.rs
+++ b/src/root.rs
@@ -17,8 +17,9 @@ pub fn get_sudo(cmd: std::process::Command) -> std::process::Command {
     if let Ok(path) = which(&program) {
         let abs_path = path.to_string_lossy().to_string();
 
+        let version_arg = if program == "pacman" { "-V" } else { "--version" };
         let check_status = Command::new("sudo")
-            .args(["-n", &abs_path, "--version"])
+            .args(["-n", &abs_path, version_arg])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status();
@@ -35,6 +36,7 @@ pub fn get_sudo(cmd: std::process::Command) -> std::process::Command {
             if let Err(e) = setup_sudoers_rule(abs_path.clone()) {
                 eprintln!("yu: failed to set up sudoers rule: {}", e);
                 eprintln!("please ensure you have permission to write to /etc/sudoers.d/uni-pkg");
+                std::process::exit(1);
             }
         }
 


### PR DESCRIPTION
## Summary
- expand package manager detection paths
- correct string comparison for unknown manager
- print command when `--verbose`
- fix sudo check for pacman and exit on failure
- generate proper pacman syntax and call `emerge` directly
- adjust autoremove, reinstall and uninstall pacman commands
- update tests

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68424585fbcc8327bf1eb9683d773603